### PR TITLE
feat: add syncClient.signalEvent

### DIFF
--- a/network/index.js
+++ b/network/index.js
@@ -3,6 +3,15 @@ const ipaddr = require('ipaddr.js')
 
 function waitNetworkInitialized ({ client, runenv }) {
   return async () => {
+    const startEvent = {
+      stage_start_event: {
+        name: 'network-initialized',
+        group: runenv.testGroupID
+      }
+    }
+
+    await client.signalEvent(startEvent)
+
     if (runenv.testSidecar) {
       try {
         const barrier = await client.barrier('network-initialized', runenv.testInstanceCount)
@@ -12,6 +21,15 @@ function waitNetworkInitialized ({ client, runenv }) {
         throw err
       }
     }
+
+    const endEvent = {
+      stage_end_event: {
+        name: 'network-initialized',
+        group: runenv.testGroupID
+      }
+    }
+
+    await client.signalEvent(endEvent)
 
     runenv.recordMessage('network initialisation successful')
   }

--- a/runtime/events.js
+++ b/runtime/events.js
@@ -1,58 +1,72 @@
-const EVENT_TYPE_START = 'start'
-const EVENT_TYPE_MESSAGE = 'message'
-const EVENT_TYPE_FINISH = 'finish'
+function newEvents ({ logger, runParams, getSignalEmitter }) {
+  const emitEvent = async (event) => {
+    const signalEmitter = getSignalEmitter()
 
-const EVENT_OUTCOME_OK = 'ok'
-const EVENT_OUTCOME_FAILED = 'failed'
-const EVENT_OUTCOME_CRASHED = 'crashed'
+    if (!signalEmitter) {
+      return
+    }
 
-function newEvents ({ logger, runParams }) {
+    try {
+      await signalEmitter.signalEvent(event)
+    } catch (_) {}
+  }
+
   return {
     recordMessage: (msg) => {
       const event = {
-        type: EVENT_TYPE_MESSAGE,
-        message: msg
+        message_event: {
+          message: msg
+        }
       }
 
       logger.info('', { event })
+      emitEvent(event)
     },
     recordStart: () => {
       const event = {
-        type: EVENT_TYPE_START,
-        runenv: runParams
+        start_event: {
+          runenv: runParams
+        }
       }
 
       logger.info('', { event })
+      emitEvent(event)
       // TODO: re.metrics.recordEvent(&evt)
     },
     recordSuccess: () => {
       const event = {
-        type: EVENT_TYPE_FINISH,
-        outcome: EVENT_OUTCOME_OK
+        success_event: {
+          group: runParams.testGroupID
+        }
       }
 
       logger.info('', { event })
+      emitEvent(event)
       // TODO: re.metrics.recordEvent(&evt)
     },
     recordFailure: (err) => {
       const event = {
-        type: EVENT_TYPE_FINISH,
-        outcome: EVENT_OUTCOME_FAILED,
-        error: err.toString()
+        failure_event: {
+          group: runParams.testGroupID,
+          error: err.toString()
+        }
       }
 
       logger.info('', { event })
+      emitEvent(event)
       // TODO: re.metrics.recordEvent(&evt)
     },
     recordCrash: (err) => {
       const event = {
-        type: EVENT_TYPE_FINISH,
-        outcome: EVENT_OUTCOME_CRASHED,
-        error: err.toString(),
-        stacktrace: err.stack
+        crash_event: {
+          group: runParams.testGroupID,
+          error: err.toString(),
+          stacktrace: err.stack
+        }
       }
 
       logger.info('', { event })
+      emitEvent(event)
       // TODO: re.metrics.recordEvent(&evt)
     }
   }

--- a/runtime/index.js
+++ b/runtime/index.js
@@ -12,15 +12,19 @@ function parseRunEnv (env) {
 }
 
 function newRunEnv (params) {
+  let signalEmitter = null
+
   const options = {
     runParams: params,
-    logger: getLogger(params)
+    logger: getLogger(params),
+    getSignalEmitter: () => signalEmitter
   }
 
   return {
     ...params,
     ...options,
-    ...newEvents(options)
+    ...newEvents(options),
+    setSignalEmitter: (e) => { signalEmitter = e }
   }
 }
 


### PR DESCRIPTION
This small PR is intended to restore the functionality of `sdk-js` which is broken due to the last updates to Testground and `sdk-go` (https://github.com/testground/sdk-go/pull/31).

What this PR does:

- Adds `signalEvent` to the sync client
- Uses the events on `network` and `runtime`

What this PR does not do:

- Add a watch client

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>