### PR TITLE
feat: add default client when requested by the test case

### DIFF
--- a/src/runtime/events.js
+++ b/src/runtime/events.js
@@ -36,7 +36,7 @@ function newEvents (runParams, logger, getSignalEmitter) {
       }
 
       logger.info('', { event })
-      emitEvent(event)
+      return emitEvent(event)
     },
     recordStart: () => {
       const event = {
@@ -46,7 +46,7 @@ function newEvents (runParams, logger, getSignalEmitter) {
       }
 
       logger.info('', { event })
-      emitEvent(event)
+      return emitEvent(event)
       // TODO(metrics): re.metrics.recordEvent(&evt)
     },
     recordSuccess: () => {
@@ -57,7 +57,7 @@ function newEvents (runParams, logger, getSignalEmitter) {
       }
 
       logger.info('', { event })
-      emitEvent(event)
+      return emitEvent(event)
       // TODO(metrics): re.metrics.recordEvent(&evt)
     },
     recordFailure: (err) => {
@@ -69,7 +69,7 @@ function newEvents (runParams, logger, getSignalEmitter) {
       }
 
       logger.info('', { event })
-      emitEvent(event)
+      return emitEvent(event)
       // TODO(metrics): re.metrics.recordEvent(&evt)
     },
     recordCrash: (err) => {
@@ -82,7 +82,7 @@ function newEvents (runParams, logger, getSignalEmitter) {
       }
 
       logger.info('', { event })
-      emitEvent(event)
+      return emitEvent(event)
       // TODO(metrics): re.metrics.recordEvent(&evt)
     }
   }


### PR DESCRIPTION
Fix #21 

* When a test case expects more than one parameter (runenv), the js sdk
  will create a default sync client and pass it to the test,
* The client will be used as a signal emitter, which makes sure that the
  test's start, success, and failure events are sent to the sync
  service.
* This mimics the behavior of `InitializedTestCaseFn` in sdk-go.