### PR TITLE
first baby steps towards native browser support for the JS sdk of testground

### DIFF
--- a/src/runtime/index.js
+++ b/src/runtime/index.js
@@ -14,7 +14,11 @@ const { parseRunParams } = require('./params')
  * @returns {RunEnv}
  */
 function currentRunEnv () {
-  return parseRunEnv(process.env)
+  if (process.name === 'browser') {
+    return parseRunEnv(window.testground.env)
+  } else {
+    return parseRunEnv(process.env)
+  }
 }
 
 /**

--- a/src/runtime/index.js
+++ b/src/runtime/index.js
@@ -14,7 +14,7 @@ const { parseRunParams } = require('./params')
  * @returns {RunEnv}
  */
 function currentRunEnv () {
-  if (process.name === 'browser') {
+  if (process.title === 'browser') {
     return parseRunEnv(window.testground.env)
   } else {
     return parseRunEnv(process.env)

--- a/src/runtime/index.js
+++ b/src/runtime/index.js
@@ -52,6 +52,5 @@ function newRunEnv (params) {
 module.exports = {
   newRunEnv,
   currentRunEnv,
-  parseRunEnv,
-  parseRunParams
+  parseRunEnv
 }

--- a/src/runtime/index.js
+++ b/src/runtime/index.js
@@ -52,5 +52,6 @@ function newRunEnv (params) {
 module.exports = {
   newRunEnv,
   currentRunEnv,
-  parseRunEnv
+  parseRunEnv,
+  parseRunParams
 }

--- a/src/runtime/logger.js
+++ b/src/runtime/logger.js
@@ -22,7 +22,7 @@ function getLogger (params) {
     new winston.transports.Console({ format }),
   ]
 
-  if (!params.testFromBrowser) {
+  if (process.name !== 'browser') {
     transports.push(new winston.transports.File({
       format,
       filename: 'stdout'

--- a/src/runtime/logger.js
+++ b/src/runtime/logger.js
@@ -22,7 +22,7 @@ function getLogger (params) {
     new winston.transports.Console({ format }),
   ]
 
-  if (process.name !== 'browser') {
+  if (process.title !== 'browser') {
     transports.push(new winston.transports.File({
       format,
       filename: 'stdout'

--- a/src/runtime/logger.js
+++ b/src/runtime/logger.js
@@ -20,14 +20,20 @@ function getLogger (params) {
 
   const transports = [
     new winston.transports.Console({ format }),
-    new winston.transports.File({ filename: 'stdout', format })
   ]
 
-  if (params.testOutputsPath) {
+  if (!params.testFromBrowser) {
     transports.push(new winston.transports.File({
       format,
-      filename: path.join(params.testOutputsPath, 'run.out')
+      filename: 'stdout'
     }))
+
+    if (!params.testOutputsPath) {
+      transports.push(new winston.transports.File({
+        format,
+        filename: path.join(params.testOutputsPath, 'run.out')
+      }))
+    }
   }
 
   return winston.createLogger({

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -10,7 +10,6 @@ export interface RunParams {
   testInstanceParams: Record<string, string>
   testInstanceRole: string
   testOutputsPath: string
-  testFromBrowser: boolean
   testPlan: string
   testRepo: string
   testRun: string

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -10,6 +10,7 @@ export interface RunParams {
   testInstanceParams: Record<string, string>
   testInstanceRole: string
   testOutputsPath: string
+  testFromBrowser: boolean
   testPlan: string
   testRepo: string
   testRun: string


### PR DESCRIPTION
I am by far no NodeJS expert, so please do help me adapt to this culture where you see fit.

With this PR I distinguish in some first starter locations between the browser and node environment. Currently I do this using `process.title`:

- within the NodeJS environment this is the value of your `ps` (see: https://nodejs.org/api/process.html#processtitle)
- when web-packing sdk-js with the process capabilities poly-filled (shimmed?) using the `process` shim package it sets this to `browser` as the title: <https://github.com/defunctzombie/node-process/blob/master/browser.js#L155>

Seems to me like a clean way, but if there's a more natural way, do let me know.

Currently there are the following changes where we differentiate between browser and NodeJS:

- creating a runtime uses the `process.env`, this is however not available in browser (and it is empty using the shim pacakge), so here we opt to assume that the env variables are available under `window.testground.env`, which are to be injected by the user of the js sdk in the browser;
- for the logging we currently also create a file on the local FS (the output log file?), this is not possible in browser, so I just disable that single output, other outputs do still function;

This is just the beginning though, I imagine there is even more we can do and want to do if native browser support for sdk-js is what we want. My current aim is to make it as easy to use as in NodeJS, meaning that the code can just be used and it will pull all it needs in the background (e.g. env variables).

Things to keep in mind...

1. for now we still need to polyfill a lot when web-packing, e.g. this is what I have for a testground plan in my webpack config file:

```js
resolve: {
    extensions: ['.js'],
    fallback: {
      fs: false,
      os: require.resolve('os-browserify'),
      path: require.resolve('path-browserify'),
      https: require.resolve('https-browserify'),
      crypto: require.resolve('crypto-browserify'),
      http: require.resolve('stream-http'),
      zlib: require.resolve('browserify-zlib'),
      buffer: require.resolve('buffer/'),
      url: require.resolve('url/'),
      'assert/': require.resolve('assert/'),
      stream: require.resolve('stream-browserify')
    }
  },
  plugins: [
    new webpack.ProvidePlugin({
      Buffer: ['buffer', 'Buffer']
    }),
    new webpack.ProvidePlugin({
      process: 'process/browser'
    })
  ],
```

Could be great if out of the box, the sdk-js already does a lot of that for us, or ensures that what it uses is more cross-platform and thus does not need to be shimmed? 

2. I am no expert of this library, so there might be even more places where we need to add some different logic for clean browser support. Please do point me to these locations if you know of any.

Finally we might also want to add some documentation on pointers for some gotcha's, hints, etc. All related to usage in browser.