### PR TITLE
minor sdk-js fix: print stack trace for unexpected plan crashes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,7 @@ async function invokeMap (cases) {
  * @param {RunEnv} runenv
  */
 function registerAndMessageTestcaseResult (result, runenv) {
-  if ('stack' in result) {
+  if (result && result.stack) {
     runenv.recordMessage(`registerTestcaseResult: ${result}; ${result.stack}`)
   } else {
     runenv.recordMessage(`registerTestcaseResult: ${result}`)

--- a/src/index.js
+++ b/src/index.js
@@ -34,11 +34,10 @@ async function invokeMap (cases) {
 }
 
 /**
- * @param {unknown} result
+ * @param {any} result
  * @param {RunEnv} runenv
  */
 function registerAndMessageTestcaseResult (result, runenv) {
-  // @ts-ignore
   if ('stack' in result) {
     runenv.recordMessage(`registerTestcaseResult: ${result}; ${result.stack}`)
   } else {

--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,12 @@ async function invokeMap (cases) {
  * @param {RunEnv} runenv
  */
 function registerAndMessageTestcaseResult (result, runenv) {
-  runenv.recordMessage(`registerTestcaseResult: ${result}`)
+  // @ts-ignore
+  if ('stack' in result) {
+    runenv.recordMessage(`registerTestcaseResult: ${result}; ${result.stack}`)
+  } else {
+    runenv.recordMessage(`registerTestcaseResult: ${result}`)
+  }
   registerTestcaseResult(result)
 }
 


### PR DESCRIPTION
To aid in debugging testplans.
As it means you also get a sense of where the error comes from,
rather than just some out-of-the-blue error message.